### PR TITLE
Fix tooltip builder call argument list

### DIFF
--- a/armory/source/character-talents.php
+++ b/armory/source/character-talents.php
@@ -151,7 +151,7 @@ function spell_info_for_talent(array $talRow, int $rank = 0) {
         return ['name' => 'Unknown', 'desc' => '', 'icon' => 'inv_misc_questionmark'];
     }
 
-    $desc = build_tooltip_desc($sp, $useRank, $maxRank);
+    $desc = build_tooltip_desc($sp);
 
     $icon = strtolower(preg_replace('/[^a-z0-9_]/i', '', (string)($sp['icon'] ?? '')));
     if ($icon === '') $icon = 'inv_misc_questionmark';


### PR DESCRIPTION
## Summary
- update spell_info_for_talent to call build_tooltip_desc with the expected argument list

## Testing
- php -l armory/source/character-talents.php

------
https://chatgpt.com/codex/tasks/task_e_68cb3386f12c8331ab66edbb4ee51355