### PR TITLE
Add Talent Calculator link to Armory menu

### DIFF
--- a/armory/shared/global/menu/de_de/menutree.js
+++ b/armory/shared/global/menu/de_de/menutree.js
@@ -34,7 +34,7 @@ Menu1_3=new Array("Game Guide","info/default.htm","reg",dv3,dv4,dv5,dv6,dv7,dv8,
 
 /*Workshop Menu1_*/
 Menu1_4=new Array("Workshop","","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
-Menu1_4_1=new Array("Armory","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+Menu1_4_1=new Array("Armory","index.php","reg",8,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_1=new Array("Charakterprofile","index.php?searchType=characters","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_2=new Array("Gildenprofile","index.php?searchType=guilds","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 	Menu1_4_1_3=new Array("Teamprofile","index.php?searchType=arenateams","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
@@ -48,6 +48,7 @@ Menu1_4_1=new Array("Armory","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv
 		Menu1_4_1_6_2=new Array("3v3 Teamrangliste","index.php?searchType=team&type=3","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 		Menu1_4_1_6_3=new Array("5v5 Teamrangliste","index.php?searchType=team&type=5","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_7=new Array("Gegenst&auml;nde","index.php?searchType=items","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+    Menu1_4_1_8=new Array("Talentrechner","../index.php?n=server.talents","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 
 
 /*Media Menu1_*/

--- a/armory/shared/global/menu/en_us/menutree_tbc.js
+++ b/armory/shared/global/menu/en_us/menutree_tbc.js
@@ -34,7 +34,7 @@ Menu1_3=new Array("Game Guide","info/default.htm","reg",dv3,dv4,dv5,dv6,dv7,dv8,
 
 /*Workshop Menu1_*/
 Menu1_4=new Array("Workshop","","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
-Menu1_4_1=new Array("Armory","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+Menu1_4_1=new Array("Armory","index.php","reg",8,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_1=new Array("Character Profiles","index.php?searchType=characters","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_2=new Array("Guild Profiles","index.php?searchType=guilds","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 	Menu1_4_1_3=new Array("Team Profiles","index.php?searchType=arenateams","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
@@ -48,6 +48,7 @@ Menu1_4_1=new Array("Armory","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv
 		Menu1_4_1_6_2=new Array("3v3 Team Ranking","index.php?searchType=team&type=3","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 		Menu1_4_1_6_3=new Array("5v5 Team Ranking","index.php?searchType=team&type=5","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_7=new Array("Items","index.php?searchType=items","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+    Menu1_4_1_8=new Array("Talent Calculator","../index.php?n=server.talents","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 
 
 /*Media Menu1_*/

--- a/armory/shared/global/menu/en_us/menutree_vanilla.js
+++ b/armory/shared/global/menu/en_us/menutree_vanilla.js
@@ -34,11 +34,12 @@ Menu1_3=new Array("Game Guide","info/default.htm","reg",dv3,dv4,dv5,dv6,dv7,dv8,
 
 /*Workshop Menu1_*/
 Menu1_4=new Array("Workshop","","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
-Menu1_4_1=new Array("Armory","index.php","reg",4,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+Menu1_4_1=new Array("Armory","index.php","reg",5,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_1=new Array("Character Profiles","index.php?searchType=characters","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_2=new Array("Guild Profiles","index.php?searchType=guilds","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 	Menu1_4_1_3=new Array("Honor Ranking","index.php?searchType=honor","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_4=new Array("Items","index.php?searchType=items","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+    Menu1_4_1_5=new Array("Talent Calculator","../index.php?n=server.talents","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 
 
 /*Media Menu1_*/

--- a/armory/shared/global/menu/en_us/menutree_wotlk.js
+++ b/armory/shared/global/menu/en_us/menutree_wotlk.js
@@ -34,7 +34,7 @@ Menu1_3=new Array("Game Guide","info/default.htm","reg",dv3,dv4,dv5,dv6,dv7,dv8,
 
 /*Workshop Menu1_*/
 Menu1_4=new Array("Workshop","","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
-Menu1_4_1=new Array("Armory","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+Menu1_4_1=new Array("Armory","index.php","reg",8,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_1=new Array("Character Profiles","index.php?searchType=characters","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_2=new Array("Guild Profiles","index.php?searchType=guilds","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 	Menu1_4_1_3=new Array("Team Profiles","index.php?searchType=arenateams","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
@@ -48,6 +48,7 @@ Menu1_4_1=new Array("Armory","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv
 		Menu1_4_1_6_2=new Array("3v3 Team Ranking","index.php?searchType=team&type=3","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 		Menu1_4_1_6_3=new Array("5v5 Team Ranking","index.php?searchType=team&type=5","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_7=new Array("Items","index.php?searchType=items","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+    Menu1_4_1_8=new Array("Talent Calculator","../index.php?n=server.talents","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 
 
 /*Media Menu1_*/

--- a/armory/shared/global/menu/fr_fr/menutree.js
+++ b/armory/shared/global/menu/fr_fr/menutree.js
@@ -34,7 +34,7 @@ Menu1_3=new Array("Game Guide","info/default.htm","reg",dv3,dv4,dv5,dv6,dv7,dv8,
 
 /*Workshop Menu1_*/
 Menu1_4=new Array("Interactif","","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
-Menu1_4_1=new Array("L'Armurerie","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+Menu1_4_1=new Array("L'Armurerie","index.php","reg",8,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_1=new Array("Fiches de perso.","index.php?searchType=characters","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_2=new Array("Fiches de guilde","index.php?searchType=guilds","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 	Menu1_4_1_3=new Array("Fiches d'équipe","index.php?searchType=arenateams","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
@@ -48,6 +48,7 @@ Menu1_4_1=new Array("L'Armurerie","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv
 		Menu1_4_1_6_2=new Array("Equipe 3c3&#160;","index.php?searchType=team&type=3","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 		Menu1_4_1_6_3=new Array("Equipe 5c5&#160;","index.php?searchType=team&type=5","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_7=new Array("Objets","index.php?searchType=items","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+    Menu1_4_1_8=new Array("Calculateur de talents","../index.php?n=server.talents","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 
 
 /*Media Menu1_*/

--- a/armory/shared/global/menu/ru_ru/menutree.js
+++ b/armory/shared/global/menu/ru_ru/menutree.js
@@ -34,7 +34,7 @@ Menu1_3=new Array("Game Guide","info/default.htm","reg",dv3,dv4,dv5,dv6,dv7,dv8,
 
 /*Workshop Menu1_*/
 Menu1_4=new Array("Workshop","","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
-Menu1_4_1=new Array("Armory","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+Menu1_4_1=new Array("Armory","index.php","reg",8,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_1=new Array("Персонажи","index.php?searchType=characters","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_2=new Array("Гильдии","index.php?searchType=guilds","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 	Menu1_4_1_3=new Array("Команды","index.php?searchType=arenateams","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
@@ -48,6 +48,7 @@ Menu1_4_1=new Array("Armory","index.php","reg",7,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv
 		Menu1_4_1_6_2=new Array("3v3 Рейт. Команды","index.php?searchType=team&type=3","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 		Menu1_4_1_6_3=new Array("5v5 Рейт. Команды","index.php?searchType=team&type=5","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
     Menu1_4_1_7=new Array("Предметы","index.php?searchType=items","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
+    Menu1_4_1_8=new Array("Калькулятор талантов","../index.php?n=server.talents","reg",dv3,dv4,dv5,dv6,dv7,dv8,dv9,dv10,dv11,dv12,dv13,dv14,dv15,dv16);
 
 
 /*Media Menu1_*/


### PR DESCRIPTION
## Summary
- add a Talent Calculator option to the Armory dropdown menu for all supported locales/expansions
- link the new menu entry to the existing server talent calculator page

## Testing
- not run (not requested)

------
https://chatgpt.com/codex/tasks/task_e_68d20d32f39c8331ac67eeaa4d58f7f0