### PR TITLE
Refine talent calculator integration

### DIFF
--- a/armory/index.php
+++ b/armory/index.php
@@ -115,6 +115,31 @@ else
 <link rel="stylesheet" type="text/css" href="css/armory-tooltips.css" />
 <script src="source/ajax/coreajax.js" type="text/javascript"></script>
 <script src="source/ajax/tooltipajax.js" type="text/javascript"></script>
+<?php
+  $loadTalentCalcAssets = false;
+  if (defined('REQUESTED_ACTION')) {
+    if (REQUESTED_ACTION === 'talentscalc') {
+      $loadTalentCalcAssets = true;
+    } elseif (
+      REQUESTED_ACTION === 'profile' &&
+      isset($_GET['charPage']) &&
+      $_GET['charPage'] === 'talentcalc'
+    ) {
+      $loadTalentCalcAssets = true;
+    }
+  }
+
+  if ($loadTalentCalcAssets) {
+    $calcCssFile = __DIR__ . '/css/talents-calc.css';
+    $calcJsFile  = __DIR__ . '/js/talents-calc.js';
+    $calcCssSuffix = is_file($calcCssFile) ? ('?v=' . filemtime($calcCssFile)) : '';
+    $calcJsSuffix  = is_file($calcJsFile) ? ('?v=' . filemtime($calcJsFile)) : '';
+?>
+<link rel="stylesheet" href="/armory/css/talents-calc.css<?php echo $calcCssSuffix; ?>">
+<script defer src="/armory/js/talents-calc.js<?php echo $calcJsSuffix; ?>"></script>
+<?php
+  }
+?>
 <!-- From the old armory - End -->
 <div id="containerJavascript"></div>
 </head>

--- a/armory/source/talent-calc.php
+++ b/armory/source/talent-calc.php
@@ -352,27 +352,15 @@ if ($hasCharTalent) {
 $hasCharSpell = tbl_exists('char', 'character_spell');
 
 ?>
-<!DOCTYPE html>
-<html lang="en">
-<head>
-  <meta charset="UTF-8">
-  <title>Character Talents Calculator</title>
-  <?php
-    $cssPath = $_SERVER['DOCUMENT_ROOT'].'/armory/css/talents-calc.css';
-    $jsPath  = $_SERVER['DOCUMENT_ROOT'].'/armory/js/talents-calc.js';
-  ?>
-  <link rel="stylesheet" href="/armory/css/talents-calc.css<?= is_file($cssPath) ? '?v='.filemtime($cssPath) : '' ?>">
-  <script defer src="/armory/js/talents-calc.js<?= is_file($jsPath) ? '?v='.filemtime($jsPath) : '' ?>"></script>
-</head>
-<body class="show-guides">
-
-<div class="parchment-top">
-  <div class="parch-profile-banner" id="banner" style="position: absolute;margin-left: 450px!important;margin-top: -110px!important;">
-    <h1 style="padding-top: 12px!important;"><?php echo $lang["talentscalc"] ?></h1>
-  </div>
+<?php
+$talentCalcStandalone = defined('REQUESTED_ACTION') && REQUESTED_ACTION === 'talentscalc';
+$talentCalcHeading = $lang['talentscalc'] ?? 'Talents Calculator';
+?>
+<?php if ($talentCalcStandalone): ?>
+<div class="parch-profile-banner" id="banner" style="position: absolute;margin-left: 450px!important;margin-top: -110px!important;">
+  <h1 style="padding-top: 12px!important;"><?php echo $talentCalcHeading; ?></h1>
 </div>
-
-<div class="parchment-content">
+<?php endif; ?>
 
 <?php if (empty($tabs)): ?>
   <em>No talent tabs found for this class.</em>
@@ -591,7 +579,6 @@ echo '<div class="'.$cellClass.'" style="--icon:url(\''.$iconQ.'\')"'
 </div><!-- /.tc-container -->
 <?php endif; ?>
 
-</div><!-- /.parchment-content -->
 <script>
 (function(){
   const root   = document.getElementById('tc-root');
@@ -719,6 +706,3 @@ echo '<div class="'.$cellClass.'" style="--icon:url(\''.$iconQ.'\')"'
   }
 })();
 </script>
-
-</body>
-</html>


### PR DESCRIPTION
## Summary
- load the talent calculator stylesheet and script from the main template when the standalone calculator or profile tab is requested
- trim the calculator include down to the actual UI markup/scripts so it no longer emits its own document wrapper or duplicate parchment containers

## Testing
- php -l armory/index.php
- php -l armory/source/talent-calc.php


------
https://chatgpt.com/codex/tasks/task_e_68d2c66b391c8331a9cfe2718e57e34b