### PR TITLE
Hide realm dropdown when only one realm exists

### DIFF
--- a/armory/index.php
+++ b/armory/index.php
@@ -73,6 +73,7 @@ if(isset($_GET["searchType"]) && isset($PagesArray[$_GET["searchType"]]))
 }
 session_start();
 initialize_realm();
+$armoryHasMultipleRealms = is_array($realms) && count($realms) > 1;
 require "configuration/".LANGUAGE."/languagearray.php";
 function session_security($fingerprint = "fingerprint001")
 {
@@ -245,6 +246,7 @@ else
 
 
 </script>
+<?php if ($armoryHasMultipleRealms): ?>
 <div class="dropdown1" onMouseOut="javascript: varOverRealm = 0;" onMouseOver="javascript: varOverRealm = 1;">
 <a class="profile-stats" href="javascript: document.formDropdownRealm.dummyLang.focus();" id="displayRealm"><?php echo DefaultRealmName ?></a>
 </div>
@@ -270,14 +272,10 @@ foreach($realms as $key => $data)
     $query['realm'] = str_replace(" ", "%20", $key);
     $query_result = http_build_query($query);
     if (isset($_GET["searchQuery"]))
-        echo "<a href=\"javascript: selectRealm('",addslashes($key),"'); window.location.href='index.php?".addslashes($query_result)."';\">",$key,"</a>";
+        echo "<a href=\"javascript: selectRealm('".addslashes($key)."'); window.location.href='index.php?".addslashes($query_result)."';\">".$key."</a>";
     else
-        echo "<a href=\"javascript: selectRealm('",addslashes($key),"');\">",$key,"</a>";
+        echo "<a href=\"javascript: selectRealm('".addslashes($key)."');\">".$key."</a>";
 }
-?>
-<?php
-if (isset($_GET["realm"]))
-    echo "<script type=\"text/javascript\"> searchRealm = '",addslashes($_GET["realm"]),"';</script>";
 ?>
 </td><td class="r"><q></q></td>
 </tr>
@@ -287,6 +285,16 @@ if (isset($_GET["realm"]))
 </table>
 </div>
 </div>
+<?php else: ?>
+<div class="dropdown1">
+<span class="profile-stats" id="displayRealm"><?php echo DefaultRealmName ?></span>
+</div>
+<?php endif; ?>
+<?php if (isset($_GET["realm"])): ?>
+<script type="text/javascript">
+    searchRealm = '<?php echo addslashes($_GET["realm"]); ?>';
+</script>
+<?php endif; ?>
 <div class="lrs"></div>
 </div>
 </div>

--- a/templates/offlike/body_header.php
+++ b/templates/offlike/body_header.php
@@ -184,17 +184,40 @@ if($user['id']>0):
 <?php
 if ((int)$MW->getConfig->generic_values->realm_info->multirealm):
     $realms = $DB->select("SELECT `id`,`name` FROM `realmlist` ORDER by id DESC");
+    $realmCount = (is_array($realms) ? count($realms) : 0);
+    $currentRealmName = '';
+    if ($realmCount) {
+        foreach ($realms as $realm) {
+            if ((int)$realm['id'] === (int)$user['cur_selected_realmd']) {
+                $currentRealmName = $realm['name'];
+                break;
+            }
+        }
+        if ($currentRealmName === '') {
+            $currentRealmName = $realms[0]['name'];
+        }
+    }
+    if ($realmCount > 1):
 ?>
                 <div onmouseover="myshow('realmdropdown');" id="droppfo" onmouseout="myhide('realmdropdown');">
                   <div style="overflow: hidden; visibility: inherit; display: block; cursor: default; background-color: transparent; background-image: url(<?php echo $currtmp; ?>/images/countrymenu-bg.gif); height: 19px; padding-left: 9px; padding-top: 2px;"><a class="menufillertop"><?php lang('realm_menu'); ?>:</a><img src="<?php echo $currtmp; ?>/images/pixel.gif" alt=""/></div>
                   <div id="realmdropdown" style="height: auto; visibility:hidden; display: none;">
 <?php foreach($realms as $realm): ?>
 <div OnMouseOver="this.style.backgroundColor='rgb(100, 100, 100)';" OnMouseOut="this.style.backgroundColor='rgb(29, 28, 27)';" style="cursor: pointer; background-color: rgb(29, 28, 27); color: rgb(244, 196, 0); font-family: arial,comic sans ms,technical; font-size: 12px; font-style: normal; text-align: left; background-image: url(<?php echo $currtmp; ?>/images/bullet-trans-bg.gif); width: 136px; height: 15px; padding-left: 9px; padding-top: 0px; left: 1px; top: 1px;">
-                    <a class="menuLink" style="display:block;" href="javascript:setcookie('cur_selected_realmd', '<?php echo $realm['id'];?>'); window.location.reload();"><?php echo ($user['cur_selected_realmd']==$realm['id']?'&gt; '.$realm['name']:$realm['name']);?></a> 
+                    <a class="menuLink" style="display:block;" href="javascript:setcookie('cur_selected_realmd', '<?php echo $realm['id'];?>'); window.location.reload();"><?php echo ($user['cur_selected_realmd']==$realm['id']?'&gt; '.$realm['name']:$realm['name']);?></a>
 </div><?php endforeach; ?>
                   </div>
                 </div>
+<?php elseif ($currentRealmName !== ''): ?>
+                <div id="droppfo">
+                  <div style="overflow: hidden; visibility: inherit; display: block; cursor: default; background-color: transparent; background-image: url(<?php echo $currtmp; ?>/images/countrymenu-bg.gif); height: 19px; padding-left: 9px; padding-top: 2px;">
+                    <a class="menufillertop"><?php lang('realm_menu'); ?>:</a>
+                    <span style="color: rgb(224, 184, 0); font-size: 10px; padding-left: 4px;"><?php echo htmlspecialchars($currentRealmName, ENT_QUOTES, 'UTF-8'); ?></span>
+                    <img src="<?php echo $currtmp; ?>/images/pixel.gif" alt=""/>
+                  </div>
+                </div>
 <?php
+    endif;
     unset($realms);
 endif;
 ?>


### PR DESCRIPTION
## Summary
- hide the Armory realm picker dropdown when only one realm is configured while keeping the currently selected realm visible
- fall back to a static realm label in the main site header if there is only a single realm available

## Testing
- php -l armory/index.php
- php -l templates/offlike/body_header.php

------
https://chatgpt.com/codex/tasks/task_e_68d34c1cdcf88331a6cc38be145a8c65